### PR TITLE
Code Block Style Width and Over Page Issue

### DIFF
--- a/about_me.typ
+++ b/about_me.typ
@@ -6,8 +6,8 @@
     par([本书（也就是仓库#link("https://www.github.com/dashuai009/pbrt-v4-zh")[pbrt-v4-zh]）由gpt翻译而来。])
     par[
       本书使用
-      #link("https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh-hans")[知识共享署名—非商业性使用—相同方式共享4.0国际公共许可协议],
-      进行许可,
+      #link("https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh-hans")[知识共享署名—非商业性使用—相同方式共享4.0国际公共许可协议]
+      进行许可。
     ]
   }
 }

--- a/template.typ
+++ b/template.typ
@@ -24,7 +24,6 @@
     set text(lang: "zh")
     cn_body
   }
-
 }
 
 // 中英文替换
@@ -43,12 +42,9 @@
 
 
 #let pbrt(it) = {
-
   set page(paper: "a4", margin: 0cm)
 
-  figure(
-    image("bookcover-4ed.jpg", width: 100%, height: 100%),
-  )
+  figure(image("bookcover-4ed.jpg", width: 100%, height: 100%))
 
   set cite(form: "year")
 
@@ -99,14 +95,20 @@
 
   // Display block code in a larger block
   // with more padding.
+  // Fix
+  // 1. Empty parts of a breakable blocks
+  //    https://github.com/typst/typst/issues/2914#issuecomment-2423965018
+  // 2. Width of Code Block -> 100%
   show raw.where(block: true): it => {
     show raw.line: it => {
       text(fill: gray)[#it.number]
       h(1em)
       it.body
     }
-    block(fill: luma(240), inset: 10pt, radius: 4pt)[#it]
+    [#it]
   }
+  show raw.where(block: true): set block(fill: luma(230), inset: 10pt, width: 100%)
+
   show outline.entry.where(level: 1): it => {
     v(12pt, weak: true)
     strong(it)


### PR DESCRIPTION
1. Code Block Width -> 100%
2. Fill/stroke skipping for empty parts of a breakable blocks fails with nested block


<img width="1044" alt="image" src="https://github.com/user-attachments/assets/574992cf-0672-4869-a001-c0403c865fda" />
