### PR TITLE
修改了图片、公式、章节的引用样式

### DIFF
--- a/chapter-1-Introduction/chapter-1.3-pbrt_System_Overview.typ
+++ b/chapter-1-Introduction/chapter-1.3-pbrt_System_Overview.typ
@@ -166,9 +166,9 @@
 ]
 
 #parec[
-  While `pbrt` can render many scenes well with its current implementation, it has frequently been extended by students,researchers, and developers. Throughout this section are a number of notable images from those efforts.@fig:competition-snow,@fig:ice-cave, and @fig:cotton-candy were each created by students in a rendering course where the final class project was to extend `pbrt` with new functionality in order to render an image that it could not have rendered before. These images are among the best from that course.
+  While `pbrt` can render many scenes well with its current implementation, it has frequently been extended by students,researchers, and developers. Throughout this section are a number of notable images from those efforts. @fig:competition-snow, @fig:ice-cave, and @fig:cotton-candy were each created by students in a rendering course where the final class project was to extend `pbrt` with new functionality in order to render an image that it could not have rendered before. These images are among the best from that course.
 ][
-  虽然 `pbrt` 可以通过其当前实现很好地渲染许多场景，但它经常被学生、研究人员和开发者扩展。在这一部分中，有许多来自这些努力的值得注意的图像。@fig:competition-snow,@fig:ice-cave, and @fig:cotton-candy 都是由参加渲染课程的学生创建的，最后的课程项目是为 `pbrt` 添加新功能，以渲染它之前无法渲染的图像。这些图像是该课程中的佼佼者。
+  虽然 `pbrt` 可以通过其当前实现很好地渲染许多场景，但它经常被学生、研究人员和开发者扩展。在这一部分中，有许多来自这些努力的值得注意的图像。@fig:competition-snow, @fig:ice-cave，和@fig:cotton-candy 都是由参加渲染课程的学生创建的，最后的课程项目是为 `pbrt` 添加新功能，以渲染它之前无法渲染的图像。这些图像是该课程中的佼佼者。
 ]
 
 #figure(

--- a/template.typ
+++ b/template.typ
@@ -148,6 +148,94 @@
     strong(it)
   }
 
+  show ref: it => {
+    let eq = math.equation
+    let el = it.element
+
+    if el != none and el.func() == math.equation {
+      // Override equation references.
+      context {
+        let text_lang = text.lang
+        let eqt_suf = if text_lang == "zh" {
+          "公式"
+        } else {
+          "Equation"
+        }
+        link(
+          el.location(),
+          [#text(eqt_suf) #numbering(
+              el.numbering,
+              ..counter(math.equation).at(el.location()),
+            )],
+        )
+      }
+    } else if el != none and el.func() == heading {
+      // Override equation references.
+      context {
+        let text_lang = text.lang
+        let sz = counter(heading).at(el.location()).len()
+        let prefix = if sz == 1 {
+          // chapter
+          if text_lang == "zh" {
+            "第"
+          } else {
+            "Chapter"
+          }
+        } else {
+          // section
+          if text_lang == "zh" {
+            "第"
+          } else {
+            "Section"
+          }
+        }
+        let suffix = if sz == 1 {
+          // chapter
+          if text_lang == "zh" {
+            "章"
+          } else {
+            ""
+          }
+        } else {
+          // section
+          if text_lang == "zh" {
+            "节"
+          } else {
+            ""
+          }
+        }
+        link(
+          el.location(),
+          [#text(prefix) #numbering(
+              // "see chapter 1", instand of "see chatper 1."
+              "1.1",
+              ..counter(heading).at(el.location()),
+            ) #text(suffix)],
+        )
+      }
+    } else if el != none and el.func() == figure {
+      // Override figure references.
+      context {
+        let text_lang = text.lang
+        let prefix = if text_lang == "zh" {
+          "图"
+        } else {
+          "Figure"
+        }
+        link(
+          el.location(),
+          [#text(prefix) #numbering(
+              el.numbering,
+              // see https://github.com/RubixDev/typst-i-figured/blob/main/i-figured.typ#L6
+              ..counter(figure.where(kind: "i-figured-image")).at(el.location()),
+            )],
+        )
+      }
+    } else {
+      // Other references as usual.
+      it
+    }
+  }
   // 使用 cuti 包实现伪粗体
   show: show-cn-fakebold
 


### PR DESCRIPTION
以下是一个测试typst

```
#import "template.typ": pbrt, parec

#show: pbrt


= chapter1 <chapter1>
#parec[
  test @chapter1 test
][
  测试@chapter1，

  有两个需要注意的地方，
  1. ref显示为"Chapter 1" 而不是"Chapter 1."。如果后续要修改heading的numbering，需要同步修改ref的样式。当前标题显示为"1.", ref时显示为"1"
  2. typst写`test @chapter`，没有太大问题，英文都是有空格。中文typst`测试@chapter1`，“测试”后面最好没有空格，不然渲染结果“测试”和“第1章”中间会有空格。
]
== section 1 <section1>

#parec[
  test @section1
][
  测试@section1
]

$
  "unlabel equation"
$

$
  a + a = b
$ <eqt1>
#parec[
  test labeled @eqt:eqt1
][
  测试公式，@eqt:eqt1
]

#figure(
  image("./pbr-book-website/4ed/Introduction/pha01f09.svg", width: 80%),
  caption: [test image],
) <intro-surface-scattering>

#parec[
  test figure, @fig:intro-surface-scattering
][
  测试图片：@fig:intro-surface-scattering
]
```

预览效果如下

<img width="663" alt="截屏2025-04-19 22 27 42" src="https://github.com/user-attachments/assets/a3512e3b-3521-481c-aa1f-8fff8448955a" />


<img width="620" alt="截屏2025-04-19 22 20 10" src="https://github.com/user-attachments/assets/529448e1-ce72-4cc6-a691-ec5825f02d38" />


